### PR TITLE
Add `tenantId` as a global secondary index to all Entities

### DIFF
--- a/src/main/java/com/agilecheckup/main/runner/DepartmentTableRunner.java
+++ b/src/main/java/com/agilecheckup/main/runner/DepartmentTableRunner.java
@@ -25,7 +25,7 @@ public class DepartmentTableRunner extends AbstractEntityCrudRunner<Department> 
   @Override
   protected Collection<Supplier<Optional<Department>>> getCreateSupplier() {
     Collection<Supplier<Optional<Department>>> collection = new ArrayList<>();
-    collection.add(() -> getDepartmentService().create("DepartmentName", "Department Description", "Another TenantId", "19bcdfcb-9162-4a0b-a5c3-c034702d0961"));
+    collection.add(() -> getDepartmentService().create("DepartmentName", "Department Description", "Another TenantId", "ca93d066-62af-4a49-aa46-0dd7f33ba9bc"));
     return collection;
   }
 

--- a/src/main/java/com/agilecheckup/main/runner/PerformanceCycleTableRunner.java
+++ b/src/main/java/com/agilecheckup/main/runner/PerformanceCycleTableRunner.java
@@ -29,7 +29,7 @@ public class PerformanceCycleTableRunner extends AbstractEntityCrudRunner<Perfor
         "PerformanceCycleName",
         "PerformanceCycle Description",
         "Another TenantId",
-        "19bcdfcb-9162-4a0b-a5c3-c034702d0961",
+        "ca93d066-62af-4a49-aa46-0dd7f33ba9bc",
         true,
         false
     ));

--- a/src/main/java/com/agilecheckup/persistency/entity/Company.java
+++ b/src/main/java/com/agilecheckup/persistency/entity/Company.java
@@ -4,6 +4,7 @@ import com.agilecheckup.persistency.entity.base.Tenantable;
 import com.agilecheckup.persistency.entity.person.LegalPerson;
 import com.agilecheckup.persistency.entity.person.NaturalPerson;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTypeConvertedJson;
 import lombok.*;
@@ -20,6 +21,7 @@ public class Company extends LegalPerson implements Tenantable {
 
   @NonNull
   @DynamoDBAttribute(attributeName = "tenantId")
+  @DynamoDBIndexHashKey(globalSecondaryIndexName = "tenantId-index", attributeName = "tenantId")
   private String tenantId;
 
   @DynamoDBAttribute(attributeName = "size")

--- a/src/main/java/com/agilecheckup/persistency/entity/base/TenantableEntity.java
+++ b/src/main/java/com/agilecheckup/persistency/entity/base/TenantableEntity.java
@@ -2,7 +2,13 @@ package com.agilecheckup.persistency.entity.base;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBDocument;
-import lombok.*;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 @EqualsAndHashCode(callSuper = true)
@@ -14,8 +20,8 @@ import lombok.experimental.SuperBuilder;
 @ToString(callSuper=true, includeFieldNames=true)
 public class TenantableEntity extends AuditableEntity implements Tenantable {
 
-  @DynamoDBAttribute(attributeName = "tenantId")
   @NonNull
+  @DynamoDBAttribute(attributeName = "tenantId")
+  @DynamoDBIndexHashKey(globalSecondaryIndexName = "tenantId-index", attributeName = "tenantId")
   private String tenantId;
-
 }

--- a/src/main/java/com/agilecheckup/persistency/repository/AbstractCrudRepository.java
+++ b/src/main/java/com/agilecheckup/persistency/repository/AbstractCrudRepository.java
@@ -2,9 +2,14 @@ package com.agilecheckup.persistency.repository;
 
 import com.agilecheckup.dagger.component.DaggerAwsConfigComponent;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBScanExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
 import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedScanList;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.google.common.annotations.VisibleForTesting;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.Getter;
 
 public abstract class AbstractCrudRepository<T>{
@@ -42,5 +47,18 @@ public abstract class AbstractCrudRepository<T>{
 
   public PaginatedScanList<T> findAll() {
     return dynamoDBMapper.scan(clazz, new DynamoDBScanExpression());
+  }
+
+  public PaginatedQueryList<T> findAllByTenantId(String tenantId) {
+    Map<String, AttributeValue> eav = new HashMap<>();
+    eav.put(":tenantId", new AttributeValue().withS(tenantId));
+
+    DynamoDBQueryExpression<T> queryExpression = new DynamoDBQueryExpression<T>()
+        .withIndexName("tenantId-index")
+        .withConsistentRead(false)
+        .withKeyConditionExpression("tenantId = :tenantId")
+        .withExpressionAttributeValues(eav);
+
+    return dynamoDBMapper.query(clazz, queryExpression);
   }
 }

--- a/src/main/java/com/agilecheckup/persistency/repository/CompanyRepository.java
+++ b/src/main/java/com/agilecheckup/persistency/repository/CompanyRepository.java
@@ -3,6 +3,7 @@ package com.agilecheckup.persistency.repository;
 
 import com.agilecheckup.persistency.entity.Company;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
 import com.google.common.annotations.VisibleForTesting;
 
 import javax.inject.Inject;
@@ -19,4 +20,7 @@ public class CompanyRepository extends AbstractCrudRepository<Company> {
     super(Company.class, dynamoDBMapper);
   }
 
+  public PaginatedQueryList<Company> findAllByTenantId(String tenantId) {
+    return super.findAllByTenantId(tenantId);
+  }
 }

--- a/src/test/java/com/agilecheckup/persistency/repository/AbstractRepositoryTest.java
+++ b/src/test/java/com/agilecheckup/persistency/repository/AbstractRepositoryTest.java
@@ -1,16 +1,31 @@
 package com.agilecheckup.persistency.repository;
 
+import com.agilecheckup.persistency.entity.Company;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBScanExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Map;
+
 import static com.agilecheckup.util.TestObjectFactory.GENERIC_ID_1234;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 abstract class AbstractRepositoryTest<T> {
@@ -70,6 +85,42 @@ abstract class AbstractRepositoryTest<T> {
     verify(dynamoDBMapperMock).scan(argThat(arg -> arg.isInstance(mockedT)), any(DynamoDBScanExpression.class));
   }
 
+  @Test
+  void testFindAllByTenantId_shouldCallMapperWithCorrectQueryExpression() {
+    // Given
+    String tenantId = "test-tenant-id";
+    PaginatedQueryList<T> expectedResult = mock(PaginatedQueryList.class);
+
+    // Mock the behavior of dynamoDBMapper.query
+    when(dynamoDBMapperMock.query(eq(getMockedClass()), any(DynamoDBQueryExpression.class)))
+        .thenReturn(expectedResult);
+
+    // When
+    PaginatedQueryList<Company> actualResult = getRepository().findAllByTenantId(tenantId);
+
+    // Then
+
+    // Assert
+    // Verify that dynamoDBMapper.query was called once
+    ArgumentCaptor<DynamoDBQueryExpression<T>> queryExpressionCaptor =
+        ArgumentCaptor.forClass(DynamoDBQueryExpression.class);
+    verify(dynamoDBMapperMock).query(eq(getMockedClass()), queryExpressionCaptor.capture());
+
+    DynamoDBQueryExpression<T> capturedExpression = queryExpressionCaptor.getValue();
+
+    assertEquals("tenantId-index", capturedExpression.getIndexName());
+    assertEquals("tenantId = :tenantId", capturedExpression.getKeyConditionExpression());
+    assertFalse(capturedExpression.isConsistentRead());
+
+    Map<String, AttributeValue> expressionAttributeValues = capturedExpression.getExpressionAttributeValues();
+    assertEquals(1, expressionAttributeValues.size());
+    assertEquals(tenantId, expressionAttributeValues.get(":tenantId").getS());
+
+    // Assert that the result of companyRepository.findAllByTenantId(...) is the same as the mocked PaginatedQueryList
+    assertSame(expectedResult, actualResult);
+  }
+
   abstract AbstractCrudRepository getRepository();
   abstract T createMockedT();
+  abstract Class getMockedClass();
 }

--- a/src/test/java/com/agilecheckup/persistency/repository/AnswerRepositoryTest.java
+++ b/src/test/java/com/agilecheckup/persistency/repository/AnswerRepositoryTest.java
@@ -24,4 +24,9 @@ class AnswerRepositoryTest extends AbstractRepositoryTest<Answer> {
   Answer createMockedT() {
     return createMockedAnswer(10d);
   }
+
+  @Override
+  Class getMockedClass() {
+    return Answer.class;
+  }
 }

--- a/src/test/java/com/agilecheckup/persistency/repository/AssessmentMatrixRepositoryTest.java
+++ b/src/test/java/com/agilecheckup/persistency/repository/AssessmentMatrixRepositoryTest.java
@@ -6,7 +6,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static com.agilecheckup.util.TestObjectFactory.*;
+import static com.agilecheckup.util.TestObjectFactory.GENERIC_ID_1234;
+import static com.agilecheckup.util.TestObjectFactory.createMockedAssessmentMatrix;
+import static com.agilecheckup.util.TestObjectFactory.createMockedPillarMap;
 
 @ExtendWith(MockitoExtension.class)
 class AssessmentMatrixRepositoryTest extends AbstractRepositoryTest<AssessmentMatrix> {
@@ -23,5 +25,10 @@ class AssessmentMatrixRepositoryTest extends AbstractRepositoryTest<AssessmentMa
   @Override
   AssessmentMatrix createMockedT() {
     return createMockedAssessmentMatrix(GENERIC_ID_1234, GENERIC_ID_1234, createMockedPillarMap(3, 4, "Pillar", "Category"));
+  }
+
+  @Override
+  Class getMockedClass() {
+    return AssessmentMatrix.class;
   }
 }

--- a/src/test/java/com/agilecheckup/persistency/repository/CompanyRepositoryTest.java
+++ b/src/test/java/com/agilecheckup/persistency/repository/CompanyRepositoryTest.java
@@ -1,27 +1,124 @@
 package com.agilecheckup.persistency.repository;
 
 import com.agilecheckup.persistency.entity.Company;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
+import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Map;
+
 import static com.agilecheckup.util.TestObjectFactory.createMockedCompany;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CompanyRepositoryTest extends AbstractRepositoryTest<Company> {
 
+  @Mock
+  private DynamoDBMapper dynamoDBMapper; // Mocked, not spied, for full control
+
   @InjectMocks
-  @Spy
-  private CompanyRepository companyRepository;
+  private CompanyRepository companyRepository; // companyRepository will use the mocked dynamoDBMapper
+
+  // Removed @Spy from companyRepository as we are now injecting a pure mock of DynamoDBMapper
+  // If companyRepository had other dependencies or methods needing real behavior,
+  // then @Spy and potentially a different setup for dynamoDBMapper would be needed.
 
   @Override
-  AbstractCrudRepository getRepository() {
+  AbstractCrudRepository<Company> getRepository() { // Specified generic type for clarity
     return companyRepository;
   }
 
   @Override
   Company createMockedT() {
     return createMockedCompany();
+  }
+
+  @Test
+  void testFindAllByTenantId_shouldCallMapperWithCorrectQueryExpression() {
+    // Arrange
+    String tenantId = "test-tenant-id";
+    PaginatedQueryList<Company> expectedResult = mock(PaginatedQueryList.class); // Use Mockito.mock
+
+    // Mock the behavior of dynamoDBMapper.query
+    when(dynamoDBMapper.query(eq(Company.class), any(DynamoDBQueryExpression.class)))
+        .thenReturn(expectedResult);
+
+    // Act
+    PaginatedQueryList<Company> actualResult = companyRepository.findAllByTenantId(tenantId);
+
+    // Assert
+    // Verify that dynamoDBMapper.query was called once
+    ArgumentCaptor<DynamoDBQueryExpression<Company>> queryExpressionCaptor =
+        ArgumentCaptor.forClass(DynamoDBQueryExpression.class);
+    verify(dynamoDBMapper).query(eq(Company.class), queryExpressionCaptor.capture());
+
+    DynamoDBQueryExpression<Company> capturedExpression = queryExpressionCaptor.getValue();
+
+    // Assertions on the captured query expression
+    assertEquals("tenantId-index", capturedExpression.getIndexName());
+    assertEquals("tenantId = :tenantId", capturedExpression.getKeyConditionExpression());
+    assertFalse(capturedExpression.isConsistentRead());
+
+    Map<String, AttributeValue> expressionAttributeValues = capturedExpression.getExpressionAttributeValues();
+    assertEquals(1, expressionAttributeValues.size());
+    assertEquals(tenantId, expressionAttributeValues.get(":tenantId").getS());
+
+    // Assert that the result of companyRepository.findAllByTenantId(...) is the same as the mocked PaginatedQueryList
+    assertSame(expectedResult, actualResult);
+  }
+
+  // Helper method for mocking, if needed elsewhere, or use Mockito.mock directly
+  @SuppressWarnings("unchecked")
+  private <T> PaginatedQueryList<T> mock(Class<T> type) {
+    return org.mockito.Mockito.mock(PaginatedQueryList.class);
+  }
+
+  @Test
+  void testSave_shouldUpdateExistingEntity() {
+    // Arrange
+    Company company = createMockedCompany(); // Helper method from existing test structure
+    company.setId("company-123");
+    company.setName("Initial Name");
+    company.setTenantId("tenant-abc");
+
+    // Act & Assert - First save (creation)
+    companyRepository.save(company);
+    verify(dynamoDBMapper).save(eq(company)); // Verifies it's called once with this company
+
+    // Modify the company
+    String updatedName = "Updated Name";
+    company.setName(updatedName);
+
+    // Act & Assert - Second save (update)
+    companyRepository.save(company);
+
+    // Verify save was called a second time
+    // We can capture the argument to ensure the modified company was passed
+    ArgumentCaptor<Company> companyCaptor = ArgumentCaptor.forClass(Company.class);
+    verify(dynamoDBMapper, org.mockito.Mockito.times(2)).save(companyCaptor.capture());
+
+    Company savedCompany = companyCaptor.getValue(); // Get the company passed to the second save
+    assertEquals(updatedName, savedCompany.getName());
+    assertEquals("company-123", savedCompany.getId()); // Ensure ID remains the same
+    assertEquals("tenant-abc", savedCompany.getTenantId()); // Ensure other properties are still there
+
+    // Additionally, assert that the same instance was passed if that's the expected behavior,
+    // or that key properties match if a new instance might be created internally before saving.
+    // For this test, we assume the repository passes the modified instance directly.
+    assertSame(company, savedCompany, "The same company instance should be passed to the mapper on update.");
   }
 }

--- a/src/test/java/com/agilecheckup/persistency/repository/CompanyRepositoryTest.java
+++ b/src/test/java/com/agilecheckup/persistency/repository/CompanyRepositoryTest.java
@@ -1,44 +1,22 @@
 package com.agilecheckup.persistency.repository;
 
 import com.agilecheckup.persistency.entity.Company;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
-import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
-import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Map;
-
 import static com.agilecheckup.util.TestObjectFactory.createMockedCompany;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CompanyRepositoryTest extends AbstractRepositoryTest<Company> {
 
-  @Mock
-  private DynamoDBMapper dynamoDBMapper; // Mocked, not spied, for full control
-
   @InjectMocks
-  private CompanyRepository companyRepository; // companyRepository will use the mocked dynamoDBMapper
-
-  // Removed @Spy from companyRepository as we are now injecting a pure mock of DynamoDBMapper
-  // If companyRepository had other dependencies or methods needing real behavior,
-  // then @Spy and potentially a different setup for dynamoDBMapper would be needed.
+  @Spy
+  private CompanyRepository companyRepository;
 
   @Override
-  AbstractCrudRepository<Company> getRepository() { // Specified generic type for clarity
+  AbstractCrudRepository getRepository() {
     return companyRepository;
   }
 
@@ -47,78 +25,8 @@ class CompanyRepositoryTest extends AbstractRepositoryTest<Company> {
     return createMockedCompany();
   }
 
-  @Test
-  void testFindAllByTenantId_shouldCallMapperWithCorrectQueryExpression() {
-    // Arrange
-    String tenantId = "test-tenant-id";
-    PaginatedQueryList<Company> expectedResult = mock(PaginatedQueryList.class); // Use Mockito.mock
-
-    // Mock the behavior of dynamoDBMapper.query
-    when(dynamoDBMapper.query(eq(Company.class), any(DynamoDBQueryExpression.class)))
-        .thenReturn(expectedResult);
-
-    // Act
-    PaginatedQueryList<Company> actualResult = companyRepository.findAllByTenantId(tenantId);
-
-    // Assert
-    // Verify that dynamoDBMapper.query was called once
-    ArgumentCaptor<DynamoDBQueryExpression<Company>> queryExpressionCaptor =
-        ArgumentCaptor.forClass(DynamoDBQueryExpression.class);
-    verify(dynamoDBMapper).query(eq(Company.class), queryExpressionCaptor.capture());
-
-    DynamoDBQueryExpression<Company> capturedExpression = queryExpressionCaptor.getValue();
-
-    // Assertions on the captured query expression
-    assertEquals("tenantId-index", capturedExpression.getIndexName());
-    assertEquals("tenantId = :tenantId", capturedExpression.getKeyConditionExpression());
-    assertFalse(capturedExpression.isConsistentRead());
-
-    Map<String, AttributeValue> expressionAttributeValues = capturedExpression.getExpressionAttributeValues();
-    assertEquals(1, expressionAttributeValues.size());
-    assertEquals(tenantId, expressionAttributeValues.get(":tenantId").getS());
-
-    // Assert that the result of companyRepository.findAllByTenantId(...) is the same as the mocked PaginatedQueryList
-    assertSame(expectedResult, actualResult);
-  }
-
-  // Helper method for mocking, if needed elsewhere, or use Mockito.mock directly
-  @SuppressWarnings("unchecked")
-  private <T> PaginatedQueryList<T> mock(Class<T> type) {
-    return org.mockito.Mockito.mock(PaginatedQueryList.class);
-  }
-
-  @Test
-  void testSave_shouldUpdateExistingEntity() {
-    // Arrange
-    Company company = createMockedCompany(); // Helper method from existing test structure
-    company.setId("company-123");
-    company.setName("Initial Name");
-    company.setTenantId("tenant-abc");
-
-    // Act & Assert - First save (creation)
-    companyRepository.save(company);
-    verify(dynamoDBMapper).save(eq(company)); // Verifies it's called once with this company
-
-    // Modify the company
-    String updatedName = "Updated Name";
-    company.setName(updatedName);
-
-    // Act & Assert - Second save (update)
-    companyRepository.save(company);
-
-    // Verify save was called a second time
-    // We can capture the argument to ensure the modified company was passed
-    ArgumentCaptor<Company> companyCaptor = ArgumentCaptor.forClass(Company.class);
-    verify(dynamoDBMapper, org.mockito.Mockito.times(2)).save(companyCaptor.capture());
-
-    Company savedCompany = companyCaptor.getValue(); // Get the company passed to the second save
-    assertEquals(updatedName, savedCompany.getName());
-    assertEquals("company-123", savedCompany.getId()); // Ensure ID remains the same
-    assertEquals("tenant-abc", savedCompany.getTenantId()); // Ensure other properties are still there
-
-    // Additionally, assert that the same instance was passed if that's the expected behavior,
-    // or that key properties match if a new instance might be created internally before saving.
-    // For this test, we assume the repository passes the modified instance directly.
-    assertSame(company, savedCompany, "The same company instance should be passed to the mapper on update.");
+  @Override
+  Class getMockedClass() {
+    return Company.class;
   }
 }

--- a/src/test/java/com/agilecheckup/persistency/repository/CustomQuestionRepositoryTest.java
+++ b/src/test/java/com/agilecheckup/persistency/repository/CustomQuestionRepositoryTest.java
@@ -25,4 +25,9 @@ class CustomQuestionRepositoryTest extends AbstractRepositoryTest<Question> {
   Question createMockedT() {
     return createMockedCustomQuestion(GENERIC_ID_1234);
   }
+
+  @Override
+  Class getMockedClass() {
+    return Question.class;
+  }
 }

--- a/src/test/java/com/agilecheckup/persistency/repository/DepartmentRepositoryTest.java
+++ b/src/test/java/com/agilecheckup/persistency/repository/DepartmentRepositoryTest.java
@@ -24,4 +24,9 @@ class DepartmentRepositoryTest extends AbstractRepositoryTest<Department> {
   Department createMockedT() {
     return createMockedDepartment();
   }
+
+  @Override
+  Class getMockedClass() {
+    return Department.class;
+  }
 }

--- a/src/test/java/com/agilecheckup/persistency/repository/EmployeeAssessmentRepositoryTest.java
+++ b/src/test/java/com/agilecheckup/persistency/repository/EmployeeAssessmentRepositoryTest.java
@@ -25,4 +25,9 @@ class EmployeeAssessmentRepositoryTest extends AbstractRepositoryTest<EmployeeAs
   EmployeeAssessment createMockedT() {
     return createMockedEmployeeAssessment(GENERIC_ID_1234, "Josivaldo", GENERIC_ID_1234);
   }
+
+  @Override
+  Class getMockedClass() {
+    return EmployeeAssessment.class;
+  }
 }

--- a/src/test/java/com/agilecheckup/persistency/repository/PerformanceCycleRepositoryTest.java
+++ b/src/test/java/com/agilecheckup/persistency/repository/PerformanceCycleRepositoryTest.java
@@ -25,4 +25,9 @@ class PerformanceCycleRepositoryTest extends AbstractRepositoryTest<PerformanceC
   PerformanceCycle createMockedT() {
     return createMockedPerformanceCycle(GENERIC_ID_1234, GENERIC_ID_1234);
   }
+
+  @Override
+  Class getMockedClass() {
+    return PerformanceCycle.class;
+  }
 }

--- a/src/test/java/com/agilecheckup/persistency/repository/QuestionRepositoryTest.java
+++ b/src/test/java/com/agilecheckup/persistency/repository/QuestionRepositoryTest.java
@@ -24,4 +24,9 @@ class QuestionRepositoryTest extends AbstractRepositoryTest<Question> {
   Question createMockedT() {
     return createMockedQuestion();
   }
+
+  @Override
+  Class getMockedClass() {
+    return Question.class;
+  }
 }

--- a/src/test/java/com/agilecheckup/persistency/repository/TeamRepositoryTest.java
+++ b/src/test/java/com/agilecheckup/persistency/repository/TeamRepositoryTest.java
@@ -24,4 +24,9 @@ class TeamRepositoryTest extends AbstractRepositoryTest<Team> {
   Team createMockedT() {
     return createMockedTeam();
   }
+
+  @Override
+  Class getMockedClass() {
+    return Team.class;
+  }
 }


### PR DESCRIPTION
As part of task [CRUD-UI-Criar-Departamento](https://ggoncalves.youtrack.cloud/issue/AC-2/CRUD-UI-Criar-Departamento). 

It must be allowed to fetch `Departments` by `tenantId`. A GSI was added in DynamoDB tables to all the entities considering future work when `querying` by tenantId instead of a customized *scan*.