### PR TITLE
AC-4 Add startDate and endDate support to PerformanceCycle service

### DIFF
--- a/src/main/java/com/agilecheckup/main/runner/PerformanceCycleTableRunner.java
+++ b/src/main/java/com/agilecheckup/main/runner/PerformanceCycleTableRunner.java
@@ -10,6 +10,7 @@ import lombok.extern.log4j.Log4j2;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -31,7 +32,9 @@ public class PerformanceCycleTableRunner extends AbstractEntityCrudRunner<Perfor
         "Another TenantId",
         "ca93d066-62af-4a49-aa46-0dd7f33ba9bc",
         true,
-        false
+        false,
+        new Date(),
+        new Date()
     ));
     return collection;
   }


### PR DESCRIPTION
## Summary
- Added support for `startDate` and `endDate` fields in PerformanceCycle create and update operations
- Implemented automatic `isTimeSensitive` calculation based on business rule

## Business Rule Implementation
- `isTimeSensitive = false` when neither startDate nor endDate are set
- `isTimeSensitive = true` only when endDate is present (with or without startDate)
- The system automatically calculates the correct value, ignoring any passed value

## Changes
- Updated `PerformanceCycleService` to accept Date parameters in create/update methods
- Added automatic calculation of `isTimeSensitive` based on `endDate` presence
- Updated `PerformanceCycleTableRunner` for E2E testing compatibility
- Added comprehensive tests covering all date handling scenarios

## Test plan
- [x] Run all unit tests in Perpetua project
- [x] Verify business rule enforcement in tests
- [x] Test with various date combinations
- [x] Ensure backward compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)