### PR TITLE
AC-9: Add extraDescription field to Question entity

### DIFF
--- a/src/main/java/com/agilecheckup/main/runner/AssessmentMatrixTableRunner.java
+++ b/src/main/java/com/agilecheckup/main/runner/AssessmentMatrixTableRunner.java
@@ -85,7 +85,8 @@ public class AssessmentMatrixTableRunner extends AbstractEntityCrudRunner<Assess
         15d,
         entity.getId(),
         pillar.getId(),
-        category.getId()
+        category.getId(),
+        "Extra description"
     ).ifPresent(question -> getQuestions().add(question));
   }
 

--- a/src/main/java/com/agilecheckup/main/runner/EmployeeAssessmentTableRunner.java
+++ b/src/main/java/com/agilecheckup/main/runner/EmployeeAssessmentTableRunner.java
@@ -98,7 +98,8 @@ public class EmployeeAssessmentTableRunner extends AbstractEntityCrudRunner<Empl
         15d,
         entity.getAssessmentMatrixId(),
         pillar.getId(),
-        category.getId()
+        category.getId(),
+        "Extra description"
     );
     questions.add(question);
     return question;

--- a/src/main/java/com/agilecheckup/main/runner/QuestionTableRunner.java
+++ b/src/main/java/com/agilecheckup/main/runner/QuestionTableRunner.java
@@ -47,15 +47,15 @@ public class QuestionTableRunner extends AbstractEntityCrudRunner<Question> {
     Collection<Supplier<Optional<Question>>> collection = new ArrayList<>();
     collection.add(() -> getQuestionService().create("Pergunta oficial", QuestionType.STAR_THREE, "OrinnovaSuper",
         15d,
-        "6413d36e-8716-4f97-ae87-7b4e9c2845ce", "1449ea3b-39b1-466c-bb54-f14ce984320f", "078ed4c3-abab-40c2-a237-e352b5172ee2"));
+        "6413d36e-8716-4f97-ae87-7b4e9c2845ce", "1449ea3b-39b1-466c-bb54-f14ce984320f", "078ed4c3-abab-40c2-a237-e352b5172ee2", "Extra description"));
     collection.add(() -> getQuestionService().createCustomQuestion("Pergunta custom oficial", QuestionType.CUSTOMIZED, "OrinnovaSuper",
         false, true, createMockedQuestionOptionList("OptionPrefix", 0, 5, 10, 20, 30),
-        "6413d36e-8716-4f97-ae87-7b4e9c2845ce", "39820ef9-7944-44d6-9c7e-8b5586fc0cb2", "60eb412a-00af-43cb-9f15-3308b7ff8a4c"));
+        "6413d36e-8716-4f97-ae87-7b4e9c2845ce", "39820ef9-7944-44d6-9c7e-8b5586fc0cb2", "60eb412a-00af-43cb-9f15-3308b7ff8a4c", "Extra description"));
 
     collection.add(() -> getQuestionService().createCustomQuestion("Pergunta custom oficial 2",
         QuestionType.CUSTOMIZED, "OrinnovaSuper",
         false, true, createMockedQuestionOptionList("OptionPrefix", 0, 5, 10, 20, 30),
-        assessmentMatrixId2, pillarId2, categoryId2));
+        assessmentMatrixId2, pillarId2, categoryId2, "Extra description"));
 
     return collection;
   }

--- a/src/main/java/com/agilecheckup/service/QuestionService.java
+++ b/src/main/java/com/agilecheckup/service/QuestionService.java
@@ -15,6 +15,7 @@ import com.google.common.annotations.VisibleForTesting;
 import lombok.NonNull;
 
 import javax.inject.Inject;
+import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -45,18 +46,18 @@ public class QuestionService extends AbstractCrudService<Question, AbstractCrudR
   }
 
   public Optional<Question> create(String questionTxt, QuestionType questionType, String tenantId, Double points,
-                                   String assessmentMatrixId, String pillarId, String categoryId) {
-    Question question = internalCreateQuestion(questionTxt, questionType, tenantId, points, assessmentMatrixId, pillarId, categoryId);
+                                   String assessmentMatrixId, String pillarId, String categoryId, String extraDescription) {
+    Question question = internalCreateQuestion(questionTxt, questionType, tenantId, points, assessmentMatrixId, pillarId, categoryId, extraDescription);
     return createQuestion(question);
   }
 
-  public Optional<Question> createCustomQuestion(String questionTxt, QuestionType questionType, String tenantId, boolean isMultipleChoice, boolean showFlushed, List<QuestionOption> options, String assessmentMatrixId, String pillarId, String categoryId) {
-    Question question = internalCreateCustomQuestion(questionTxt, questionType, tenantId, isMultipleChoice, showFlushed, options, assessmentMatrixId, pillarId, categoryId);
+  public Optional<Question> createCustomQuestion(String questionTxt, QuestionType questionType, String tenantId, boolean isMultipleChoice, boolean showFlushed, List<QuestionOption> options, String assessmentMatrixId, String pillarId, String categoryId, String extraDescription) {
+    Question question = internalCreateCustomQuestion(questionTxt, questionType, tenantId, isMultipleChoice, showFlushed, options, assessmentMatrixId, pillarId, categoryId, extraDescription);
     return createQuestion(question);
   }
 
   public Optional<Question> update(String id, String questionTxt, QuestionType questionType, String tenantId, Double points,
-                                   String assessmentMatrixId, String pillarId, String categoryId) {
+                                   String assessmentMatrixId, String pillarId, String categoryId, String extraDescription) {
     Optional<Question> optionalQuestion = findById(id);
     if (optionalQuestion.isPresent()) {
       Question question = optionalQuestion.get();
@@ -73,6 +74,7 @@ public class QuestionService extends AbstractCrudService<Question, AbstractCrudR
       question.setQuestionType(questionType);
       question.setTenantId(tenantId);
       question.setPoints(points);
+      question.setExtraDescription(extraDescription);
       return super.update(question);
     } else {
       return Optional.empty();
@@ -81,7 +83,7 @@ public class QuestionService extends AbstractCrudService<Question, AbstractCrudR
 
   public Optional<Question> updateCustomQuestion(String id, String questionTxt, QuestionType questionType, String tenantId,
                                                  boolean isMultipleChoice, boolean showFlushed, @NonNull List<QuestionOption> options,
-                                                 String assessmentMatrixId, String pillarId, String categoryId) {
+                                                 String assessmentMatrixId, String pillarId, String categoryId, String extraDescription) {
     Optional<Question> optionalQuestion = findById(id);
     if (optionalQuestion.isPresent()) {
       Question question = optionalQuestion.get();
@@ -99,6 +101,7 @@ public class QuestionService extends AbstractCrudService<Question, AbstractCrudR
       question.setQuestionType(questionType);
       question.setOptionGroup(createOptionGroup(isMultipleChoice, showFlushed, options));
       question.setTenantId(tenantId);
+      question.setExtraDescription(extraDescription);
       return super.update(question);
     } else {
       return Optional.empty();
@@ -107,6 +110,10 @@ public class QuestionService extends AbstractCrudService<Question, AbstractCrudR
 
   public List<Question> findByAssessmentMatrixId(String matrixId, String tenantId) {
     return questionRepository.findByAssessmentMatrixId(matrixId, tenantId);
+  }
+
+  public PaginatedQueryList<Question> findAllByTenantId(String tenantId) {
+    return questionRepository.findAllByTenantId(tenantId);
   }
 
   public boolean hasCategoryQuestions(String matrixId, String categoryId, String tenantId) {
@@ -125,7 +132,7 @@ public class QuestionService extends AbstractCrudService<Question, AbstractCrudR
   }
 
   private Question internalCreateQuestion(String questionTxt, QuestionType questionType, String tenantId, Double points,
-                                          String assessmentMatrixId, String pillarId, String categoryId) {
+                                          String assessmentMatrixId, String pillarId, String categoryId, String extraDescription) {
     AssessmentMatrix assessmentMatrix = getAssessmentMatrixById(assessmentMatrixId);
     Pillar pillar = getPillar(assessmentMatrix, pillarId);
     Category category = getCategory(pillar, categoryId);
@@ -139,13 +146,14 @@ public class QuestionService extends AbstractCrudService<Question, AbstractCrudR
         .questionType(questionType)
         .tenantId(tenantId)
         .points(points)
+        .extraDescription(extraDescription)
         .build();
   }
 
   private Question internalCreateCustomQuestion(String questionTxt, QuestionType questionType, String tenantId,
                                                 boolean isMultipleChoice, boolean showFlushed,
                                                 @NonNull List<QuestionOption> options, String assessmentMatrixId,
-                                                String pillarId, String categoryId) {
+                                                String pillarId, String categoryId, String extraDescription) {
     validateQuestionOptions(options);
     AssessmentMatrix assessmentMatrix = getAssessmentMatrixById(assessmentMatrixId);
     Pillar pillar = getPillar(assessmentMatrix, pillarId);
@@ -160,6 +168,7 @@ public class QuestionService extends AbstractCrudService<Question, AbstractCrudR
         .questionType(questionType)
         .optionGroup(createOptionGroup(isMultipleChoice, showFlushed, options))
         .tenantId(tenantId)
+        .extraDescription(extraDescription)
         .build();
   }
 

--- a/src/test/java/com/agilecheckup/service/QuestionServiceTest.java
+++ b/src/test/java/com/agilecheckup/service/QuestionServiceTest.java
@@ -256,7 +256,8 @@ class QuestionServiceTest extends AbstractCrudServiceTest<Question, AbstractCrud
     Optional<Question> questionOptional = questionService.createCustomQuestion(originalCustomQuestion.getQuestion(),
         originalCustomQuestion.getQuestionType(), originalCustomQuestion.getTenantId(), false, true,
         createMockedQuestionOptionList("OptionPrefix", 0d, 5d, 10d, 20d, 30d),
-        originalCustomQuestion.getAssessmentMatrixId(), originalCustomQuestion.getPillarId(), originalCustomQuestion.getCategoryId(), "Test extra description");
+        originalCustomQuestion.getAssessmentMatrixId(), originalCustomQuestionD.getPillarId(),
+        originalCustomQuestion.getCategoryId(), "Test extra description");
 
     // Then
     assertTrue(questionOptional.isPresent());

--- a/src/test/java/com/agilecheckup/service/QuestionServiceTest.java
+++ b/src/test/java/com/agilecheckup/service/QuestionServiceTest.java
@@ -256,7 +256,7 @@ class QuestionServiceTest extends AbstractCrudServiceTest<Question, AbstractCrud
     Optional<Question> questionOptional = questionService.createCustomQuestion(originalCustomQuestion.getQuestion(),
         originalCustomQuestion.getQuestionType(), originalCustomQuestion.getTenantId(), false, true,
         createMockedQuestionOptionList("OptionPrefix", 0d, 5d, 10d, 20d, 30d),
-        originalCustomQuestion.getAssessmentMatrixId(), originalCustomQuestionD.getPillarId(),
+        originalCustomQuestion.getAssessmentMatrixId(), originalCustomQuestion.getPillarId(),
         originalCustomQuestion.getCategoryId(), "Test extra description");
 
     // Then


### PR DESCRIPTION
## Summary
- Add extraDescription field to Question entity for additional context
- Enhance tenant security for Question operations
- Fix Mockito stubbing issues in QuestionServiceTest

## Changes
- Added extraDescription field to Question entity with proper getters/setters
- Enhanced QuestionService with tenant validation and extraDescription support
- Fixed QuestionServiceTest Mockito stubbing issues using doReturn().when() pattern
- Updated service methods to handle optional extraDescription field

## Test plan
- [x] Create questions with extraDescription field
- [x] Update questions to add/modify extraDescription
- [x] Verify null extraDescription is handled correctly
- [x] Test tenant isolation in QuestionService operations
- [x] Run all unit tests to ensure no regressions
- [x] Verify DynamoDB persistence of extraDescription field

🤖 Generated with [Claude Code](https://claude.ai/code)